### PR TITLE
Ignore case when parsing the terra env

### DIFF
--- a/tools/billing_profiles.py
+++ b/tools/billing_profiles.py
@@ -76,11 +76,8 @@ def _bpm_create_cmd(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "-e", "--env", choices=Configuration.get_environments(), required=True
-    )
-    parser.add_argument("-b", "--bee", required=False)
     parser.add_argument("-u", "--user_token", required=False)
+
     subparsers = parser.add_subparsers()
     subparsers.required = True
 
@@ -94,6 +91,7 @@ if __name__ == "__main__":
     create_subparser.add_argument("-m", "--mrg_id", required=True)
     create_subparser.add_argument("-t", "--tenant_id", required=True)
 
+    cli.setup_parser_terra_env_args(parser)
     args = cli.parse_args_and_init_config(parser)
 
     args.func(args)

--- a/tools/billing_project.py
+++ b/tools/billing_project.py
@@ -144,10 +144,6 @@ def _list_billing_projects_cmd(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "-e", "--env", choices=Configuration.get_environments(), required=True
-    )
-    parser.add_argument("-b", "--bee", required=False)
     parser.add_argument("-u", "--user_token", required=False)
 
     subparsers = parser.add_subparsers()
@@ -171,6 +167,7 @@ if __name__ == "__main__":
     list_subparser = subparsers.add_parser("list")
     list_subparser.set_defaults(func=_list_billing_projects_cmd)
 
+    cli.setup_parser_terra_env_args(parser)
     args = cli.parse_args_and_init_config(parser)
 
     args.func(args)

--- a/tools/lz.py
+++ b/tools/lz.py
@@ -191,10 +191,6 @@ def _verify_lz_definition(definition: str):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "-e", "--env", choices=Configuration.get_environments(), required=True
-    )
-    parser.add_argument("-b", "--bee", required=False)
     parser.add_argument("-u", "--user_token", required=False)
 
     subparsers = parser.add_subparsers()
@@ -217,6 +213,7 @@ if __name__ == "__main__":
     e2e_subparser.add_argument("-p", "--lz_prefix", required=False, default="test")
     e2e_subparser.set_defaults(func=_e2e_cmd)
 
+    cli.setup_parser_terra_env_args(parser)
     args = cli.parse_args_and_init_config(parser)
 
     args.func(args)

--- a/tools/mrg.py
+++ b/tools/mrg.py
@@ -114,11 +114,6 @@ def _mrg_cmd(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
-
-    parser.add_argument(
-        "-e", "--env", choices=Configuration.get_environments(), required=True
-    )
-    parser.add_argument("-b", "--bee", required=False)
     subparsers = parser.add_subparsers()
 
     create_subparser = subparsers.add_parser("create")
@@ -135,6 +130,7 @@ if __name__ == "__main__":
     delete_subparser.add_argument("-r", "--resource_group", required=True)
     delete_subparser.set_defaults(func=_delete_mrg_cmd)
 
+    cli.setup_parser_terra_env_args(parser)
     args = cli.parse_args_and_init_config(parser)
 
     args.func(args)

--- a/tools/utils/cli.py
+++ b/tools/utils/cli.py
@@ -4,6 +4,17 @@ from utils import auth
 from utils.conf import TerraEnvs, Configuration
 
 
+def setup_parser_terra_env_args(parser: argparse.ArgumentParser):
+    """
+    Add a case-insensitive, bee-aware terra environment arg
+    """
+
+    parser.add_argument(
+        "-e", "--env", choices=Configuration.get_environments(), required=True, type=str.lower
+    )
+    parser.add_argument("-b", "--bee", required=False)
+
+
 def parse_args_and_init_config(
         parser: argparse.ArgumentParser,
 ) -> (dict, argparse.ArgumentParser):


### PR DESCRIPTION
These scripts should ignore case when parsing the terra environment to ease the burden on downstream clients.