### PR TITLE
[WOR-1370] Allow specification of azure location when creating billing project

### DIFF
--- a/tools/billing_project.py
+++ b/tools/billing_project.py
@@ -25,6 +25,7 @@ def create_billing_project(
     authorized_terra_users: list[str],
     tenant_id: str,
     protected_data: bool,
+    location: str = "southcentralus"
 ):
     mrg.deploy_managed_application(
         subscription_id,
@@ -32,6 +33,7 @@ def create_billing_project(
         resource_group,
         authorized_terra_users,
         Configuration.get_config()["plan"],
+        location
     )
 
     body = {
@@ -99,6 +101,7 @@ def _create_billing_project_cmd(args):
         args.users,
         args.tenant_id,
         args.protected_data,
+        args.location
     )
 
 
@@ -159,6 +162,9 @@ if __name__ == "__main__":
     create_subparser.add_argument("-bp", "--billing_project_name", required=True)
     create_subparser.add_argument(
         "-p", "--protected_data", required=False, default=False, action="store_true"
+    )
+    create_subparser.add_argument(
+        "-l", "--location", required=False, default="southcentralus"
     )
     create_subparser.set_defaults(func=_create_billing_project_cmd)
 


### PR DESCRIPTION
This PR parameterizes the Azure location where the billing project and associated landing zone resources are deployed. The initial use case is shifting the `create-azure-billing-project` testing github workflow that is failing due to quota issues w/azure. 