### PR TITLE
WOR-1434: increase billing project deletion timeout

### DIFF
--- a/tools/billing_project.py
+++ b/tools/billing_project.py
@@ -184,7 +184,7 @@ def delete_billing_project(billing_project_name: str):
 
         return False, status
 
-    poll.poll_predicate("Billing project deletion", 1200, 5, _billing_deletion_poller)
+    poll.poll_predicate("Billing project deletion", 7200, 5, _billing_deletion_poller)
 
     logging.info("Deleted billing project")
 


### PR DESCRIPTION
Increase timeout to 2 hours to avoid failures when Azure resources are just slow to delete.